### PR TITLE
refactor(nvim): replace astronauta with native vim.keymap

### DIFF
--- a/lua/lspactions/codeaction.lua
+++ b/lua/lspactions/codeaction.lua
@@ -79,7 +79,7 @@ local function on_code_action_results(_, results, ctx, config)
     end
   end
 
-  local select = config.ui_select or require'lspactions.select'
+  local select = config.ui_select or require "lspactions.select"
 
   select(action_tuples, {
     prompt = "Code actions",

--- a/lua/lspactions/diagnostic.lua
+++ b/lua/lspactions/diagnostic.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local function severity_lsp_to_vim(severity)
-  if type(severity) == 'string' then
+  if type(severity) == "string" then
     severity = vim.lsp.protocol.DiagnosticSeverity[severity]
   end
   return severity
@@ -14,7 +14,7 @@ function M.show_position_diagnostics(opts, buf_nr, position)
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
   elseif opts.severity_limit then
-    opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
+    opts.severity = { min = severity_lsp_to_vim(opts.severity_limit) }
   end
   return vim.diagnostic.open_float(buf_nr, opts)
 end
@@ -34,7 +34,7 @@ function M.goto_next(opts)
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
     elseif opts.severity_limit then
-      opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
+      opts.severity = { min = severity_lsp_to_vim(opts.severity_limit) }
     end
   end
   return vim.diagnostic.goto_next(opts)
@@ -45,7 +45,7 @@ function M.goto_prev(opts)
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
     elseif opts.severity_limit then
-      opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
+      opts.severity = { min = severity_lsp_to_vim(opts.severity_limit) }
     end
   end
   return vim.diagnostic.goto_prev(opts)
@@ -56,7 +56,7 @@ function M.set_qflist(opts)
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
   elseif opts.severity_limit then
-    opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
+    opts.severity = { min = severity_lsp_to_vim(opts.severity_limit) }
   end
   if opts.client_id then
     opts.client_id = nil
@@ -72,7 +72,7 @@ function M.set_loclist(opts)
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
   elseif opts.severity_limit then
-    opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
+    opts.severity = { min = severity_lsp_to_vim(opts.severity_limit) }
   end
   if opts.client_id then
     opts.client_id = nil

--- a/lua/lspactions/init.lua
+++ b/lua/lspactions/init.lua
@@ -1,10 +1,9 @@
-local response_to_list = require'lspactions.location_util'.response_to_list
+local response_to_list = require("lspactions.location_util").response_to_list
 local M = {}
 
-
-M.code_action = require"lspactions.codeaction".code_action
-M.range_code_action = require"lspactions.codeaction".range_code_action
-M.codeaction = require "lspactions.codeaction".code_action_handler
+M.code_action = require("lspactions.codeaction").code_action
+M.range_code_action = require("lspactions.codeaction").range_code_action
+M.codeaction = require("lspactions.codeaction").code_action_handler
 M.rename = require "lspactions.rename"
 M.references = response_to_list(vim.lsp.util.locations_to_items, "references")
 M.definition = response_to_list(vim.lsp.util.locations_to_items, "definition")
@@ -13,8 +12,8 @@ M.implementation = response_to_list(
   vim.lsp.util.locations_to_items,
   "implementation"
 )
-M.diagnostic = require"lspactions.diagnostic"
-M.select = require"lspactions.select"
-M.input = require"lspactions.input"
+M.diagnostic = require "lspactions.diagnostic"
+M.select = require "lspactions.select"
+M.input = require "lspactions.input"
 
 return M

--- a/lua/lspactions/input.lua
+++ b/lua/lspactions/input.lua
@@ -70,7 +70,7 @@ end
 
 local function input(opts, on_confirm)
   vim.validate {
-    on_confirm = { on_confirm, 'function', false },
+    on_confirm = { on_confirm, "function", false },
   }
   opts = opts or {}
   opts.prompt = opts.prompt or "Input"

--- a/lua/lspactions/input.lua
+++ b/lua/lspactions/input.lua
@@ -1,5 +1,3 @@
-local nnoremap = vim.keymap.nnoremap
-local inoremap = vim.keymap.inoremap
 local util = require "lspactions.util"
 local popup = require "popup"
 
@@ -48,17 +46,17 @@ local function set_mappings(keymaps, buf, on_confirm)
   local quit_key_tbl = keymaps.quit
   local exec_key_tbl = keymaps.exec
   for _, k in ipairs(quit_key_tbl.n) do
-    nnoremap { k, close, buffer = buf }
+    vim.keymap.set("n", k, close, { buffer = buf })
   end
   for _, k in ipairs(quit_key_tbl.i) do
-    inoremap { k, close, buffer = buf }
+    vim.keymap.set("i", k, close, { buffer = buf })
   end
 
   for _, k in ipairs(exec_key_tbl.n) do
-    nnoremap { k, apply_action, buffer = buf }
+    vim.keymap.set("n", k, apply_action, { buffer = buf })
   end
   for _, k in ipairs(exec_key_tbl.i) do
-    inoremap { k, apply_action, buffer = buf }
+    vim.keymap.set("i", k, apply_action, { buffer = buf })
   end
 end
 

--- a/lua/lspactions/select.lua
+++ b/lua/lspactions/select.lua
@@ -1,4 +1,4 @@
-local util = require("lspactions.util")
+local util = require "lspactions.util"
 local max = util.max
 local popup = require "popup"
 
@@ -84,7 +84,12 @@ local function select(items, opts, on_choice)
     end
 
     for i = 1, #items, 1 do
-      vim.keymap.set("n", string.format("%d", i), apply_idx_selection(i), { buffer = bufnr })
+      vim.keymap.set(
+        "n",
+        string.format("%d", i),
+        apply_idx_selection(i),
+        { buffer = bufnr }
+      )
     end
   end
 

--- a/lua/lspactions/select.lua
+++ b/lua/lspactions/select.lua
@@ -1,4 +1,3 @@
-local nnoremap = vim.keymap.nnoremap
 local util = require("lspactions.util")
 local max = util.max
 local popup = require "popup"
@@ -77,19 +76,15 @@ local function select(items, opts, on_choice)
     local exec_key_tbl = keymaps.exec
 
     for _, k in ipairs(quit_key_tbl.n) do
-      nnoremap { k, close, buffer = bufnr }
+      vim.keymap.set("n", k, close, { buffer = bufnr })
     end
 
     for _, k in ipairs(exec_key_tbl.n) do
-      nnoremap { k, apply_selection, buffer = bufnr }
+      vim.keymap.set("n", k, apply_selection, { buffer = bufnr })
     end
 
     for i = 1, #items, 1 do
-      nnoremap {
-        string.format("%d", i),
-        apply_idx_selection(i),
-        buffer = bufnr,
-      }
+      vim.keymap.set("n", string.format("%d", i), apply_idx_selection(i), { buffer = bufnr })
     end
   end
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ be highly extensible and customizable. It uses floating windows for handlers
 **if it really improves workflow**(I am biased) otherwise try to provide
 similar (but highy customizable) handlers to nvim's default handlers.
 
-**lspactions require neovim 0.5.1 release**
+**lspactions require neovim nightly release**
 
 Current lspactions handlers:
 - codeaction (floating win)
@@ -29,14 +29,12 @@ free to make a PR.
 
 - [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 - [popup.nvim](https://github.com/nvim-lua/popup.nvim)
-- [astronauta.nvim](https://github.com/tjdevries/astronauta.nvim) ... for lua keymaps (I don't want to write it)
 
 ## Installation
 
 ```vim
 Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-lua/popup.nvim'
-Plug 'tjdevries/astronauta.nvim'
 Plug 'RishabhRD/lspactions'
 ```
 
@@ -123,7 +121,7 @@ exec contains mappings for keys where we accept the current input and have to ac
 it.
 
 
-**NOTE:** For neovim 0.6 nightly, it is enough to have 
+**NOTE:** For neovim 0.6 nightly, it is enough to have
 ``vim.ui.input = require'lspactions'.input`` for renaming functionality.
 If user doesn't wish to use floating buffer input globally, then user can use
 lspactions rename module.


### PR DESCRIPTION
Removes astronauta.nvim dep (looks like it's been deprecated https://github.com/tjdevries/astronauta.nvim/commit/c8e33813c92ffcc9ba2edaf9124db1f3f17e3500) 

Requires neovim nightly so might not be worth merging in yet 